### PR TITLE
fix(windows): properly implement IUnknown instead of workaround

### DIFF
--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -90,7 +90,7 @@ impl IDataObject_Impl for DataObject {
             Ok(STGMEDIUM {
                 tymed: TYMED_HGLOBAL.0 as u32,
                 u: STGMEDIUM_0 { hGlobal: self.0 },
-                pUnkForRelease: std::mem::ManuallyDrop::new(Some(DummyDropSource.into())),
+                pUnkForRelease: std::mem::ManuallyDrop::new(Some(DummyRelease.into())),
             })
         } else {
             Err(Error::new(DV_E_FORMATETC, HSTRING::new()))


### PR DESCRIPTION
Quick fix to replace previous workaround for IUnknown implementation.