### PR TITLE
chore(plugin): rename NPM package to @crabnebula/tauri-plugin-drag

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -22,7 +22,7 @@
     }
   },
   "packages": {
-    "@crabnebula/plugin-drag": {
+    "@crabnebula/tauri-plugin-drag": {
       "path": "./packages/tauri-plugin-api",
       "manager": "javascript"
     },

--- a/.changes/initial-release.md
+++ b/.changes/initial-release.md
@@ -1,5 +1,5 @@
 ---
-"@crabnebula/plugin-drag": minor
+"@crabnebula/tauri-plugin-drag": minor
 "drag": minor
 "tauri-plugin-drag": minor
 ---

--- a/README.md
+++ b/README.md
@@ -97,14 +97,14 @@ There's two ways to consume this crate API: from Rust code via the `drag` crate 
 
 `$ cargo add tauri-plugin-drag`
 
-- Install the `@crabnebula/plugin-drag` NPM package containing the API bindings:
+- Install the `@crabnebula/tauri-plugin-drag` NPM package containing the API bindings:
 
 ```sh
-pnpm add @crabnebula/plugin-drag
+pnpm add @crabnebula/tauri-plugin-drag
 # or
-npm add @crabnebula/plugin-drag
+npm add @crabnebula/tauri-plugin-drag
 # or
-yarn add @crabnebula/plugin-drag
+yarn add @crabnebula/tauri-plugin-drag
 ```
 
 - Register the core plugin with Tauri:
@@ -123,7 +123,7 @@ fn main() {
 - Afterwards all the plugin's APIs are available through the JavaScript guest bindings:
 
 ```javascript
-import { startDrag } from "@crabnebula/plugin-drag";
+import { startDrag } from "@crabnebula/tauri-plugin-drag";
 startDrag({ item: ['/path/to/drag/file'], icon: '/path/to/icon/image' })
 ```
 

--- a/packages/tauri-plugin-api/package.json
+++ b/packages/tauri-plugin-api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@crabnebula/plugin-drag",
+  "name": "@crabnebula/tauri-plugin-drag",
   "version": "0.0.0",
   "author": "Lucas <lucas@crabnebula.dev>",
   "description": "Start a drag operation out of a Tauri window",


### PR DESCRIPTION
The current name (@crabnebula/plugin-drag) isn't clear about it being a Tauri plugin.