### PR TITLE
Fix Security Mail Contact Domain

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 **Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
 
-Alternatively, you can also send them by email to security@crabnebula.com.
+Alternatively, you can also send them by email to security@crabnebula.dev.
 You can encrypt your mail using GnuPG if you want. 
 
 See the [security.txt](https://crabnebula.dev/.well-known/security.txt) from CrabNebula


### PR DESCRIPTION
This fixes a wrong contact email address in the text of the disclosure section.