### PR TITLE
Add file move support via DragMode option

### DIFF
--- a/crates/drag/src/lib.rs
+++ b/crates/drag/src/lib.rs
@@ -88,8 +88,6 @@ extern crate objc;
 use std::path::PathBuf;
 
 mod platform_impl;
-
-pub use platform_impl::cancel_drag;
 pub use platform_impl::start_drag;
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/drag/src/lib.rs
+++ b/crates/drag/src/lib.rs
@@ -145,7 +145,6 @@ pub enum DragItem {
 pub enum DragMode {
     Copy = 1,  // NSDragOperationCopy
     Move = 16, // NSDragOperationMove
-    Smart = 0, // Special case handled in dragging_session
 }
 
 impl Default for DragMode {

--- a/crates/drag/src/lib.rs
+++ b/crates/drag/src/lib.rs
@@ -89,6 +89,7 @@ use std::path::PathBuf;
 
 mod platform_impl;
 
+pub use platform_impl::cancel_drag;
 pub use platform_impl::start_drag;
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/drag/src/lib.rs
+++ b/crates/drag/src/lib.rs
@@ -140,9 +140,30 @@ pub enum DragItem {
     },
 }
 
+#[derive(Debug, Clone, Copy)]
+#[repr(u64)]
+pub enum DragMode {
+    Copy = 1,  // NSDragOperationCopy
+    Move = 16, // NSDragOperationMove
+    Smart = 0, // Special case handled in dragging_session
+}
+
+impl Default for DragMode {
+    fn default() -> Self {
+        DragMode::Copy
+    }
+}
+
+unsafe impl objc::Encode for DragMode {
+    fn encode() -> objc::Encoding {
+        unsafe { objc::Encoding::from_str("Q") } // unsigned long long
+    }
+}
+
 #[derive(Default)]
 pub struct Options {
     pub skip_animatation_on_cancel_or_failure: bool,
+    pub mode: DragMode,
 }
 
 /// An image definition.

--- a/crates/drag/src/lib.rs
+++ b/crates/drag/src/lib.rs
@@ -152,6 +152,7 @@ impl Default for DragMode {
     }
 }
 
+#[cfg(target_os = "macos")]
 unsafe impl objc::Encode for DragMode {
     fn encode() -> objc::Encoding {
         unsafe { objc::Encoding::from_str("Q") } // unsigned long long

--- a/crates/drag/src/platform_impl/gtk/mod.rs
+++ b/crates/drag/src/platform_impl/gtk/mod.rs
@@ -26,8 +26,12 @@ pub fn start_drag<F: Fn(DragResult, CursorPosition) + Send + 'static>(
     options: Options,
 ) -> crate::Result<()> {
     let handler_ids: Arc<Mutex<Vec<SignalHandlerId>>> = Arc::new(Mutex::new(vec![]));
+    let drag_action = match options.mode {
+        DragMode::Copy => gdk::DragAction::COPY,
+        DragMode::Move => gdk::DragAction::MOVE,
+    };
 
-    window.drag_source_set(gdk::ModifierType::BUTTON1_MASK, &[], gdk::DragAction::COPY);
+    window.drag_source_set(gdk::ModifierType::BUTTON1_MASK, &[], drag_action);
 
     match item {
         DragItem::Files(paths) => {
@@ -54,7 +58,7 @@ pub fn start_drag<F: Fn(DragResult, CursorPosition) + Send + 'static>(
     if let Some(target_list) = &window.drag_source_get_target_list() {
         if let Some(drag_context) = window.drag_begin_with_coordinates(
             target_list,
-            gdk::DragAction::COPY,
+            drag_action,
             gdk::ffi::GDK_BUTTON1_MASK as i32,
             None,
             -1,

--- a/crates/drag/src/platform_impl/gtk/mod.rs
+++ b/crates/drag/src/platform_impl/gtk/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use crate::{CursorPosition, DragItem, DragResult, Error, Image, Options};
+use crate::{CursorPosition, DragItem, DragMode, DragResult, Error, Image, Options};
 use gdkx11::{
     gdk,
     glib::{ObjectExt, Propagation, SignalHandlerId},

--- a/crates/drag/src/platform_impl/gtk/mod.rs
+++ b/crates/drag/src/platform_impl/gtk/mod.rs
@@ -164,7 +164,7 @@ fn on_drop_performed<F: Fn(DragResult, CursorPosition) + Send + 'static>(
     let window = window.clone();
     let handler_ids = handler_ids.clone();
 
-    drag_context.connect_drop_performed(move |_, _| {
+    drag_context.connect_drop_performed(move |context, _| {
         println!("Drop performed successfully");
         println!("Selected action: {:?}", context.selected_action());
         println!("Suggested action: {:?}", context.suggested_action());

--- a/crates/drag/src/platform_impl/gtk/mod.rs
+++ b/crates/drag/src/platform_impl/gtk/mod.rs
@@ -166,6 +166,8 @@ fn on_drop_performed<F: Fn(DragResult, CursorPosition) + Send + 'static>(
 
     drag_context.connect_drop_performed(move |_, _| {
         println!("Drop performed successfully");
+        println!("Selected action: {:?}", context.selected_action());
+        println!("Suggested action: {:?}", context.suggested_action());
         cleanup_signal_handlers(&handler_ids, &window);
         callback(DragResult::Dropped, get_cursor_position(&window).unwrap());
     });

--- a/crates/drag/src/platform_impl/gtk/mod.rs
+++ b/crates/drag/src/platform_impl/gtk/mod.rs
@@ -25,37 +25,42 @@ pub fn start_drag<F: Fn(DragResult, CursorPosition) + Send + 'static>(
     on_drop_callback: F,
     options: Options,
 ) -> crate::Result<()> {
+    println!("Starting drag operation with mode: {:?}", options.mode);
+
     let handler_ids: Arc<Mutex<Vec<SignalHandlerId>>> = Arc::new(Mutex::new(vec![]));
     let drag_action = match options.mode {
         DragMode::Copy => gdk::DragAction::COPY,
         DragMode::Move => gdk::DragAction::MOVE,
     };
 
+    println!("Setting drag source with action: {:?}", drag_action);
     window.drag_source_set(gdk::ModifierType::BUTTON1_MASK, &[], drag_action);
 
     match item {
-        DragItem::Files(paths) => {
+        DragItem::Files(ref paths) => {
+            println!("Setting up file drag with {} paths", paths.len());
             window.drag_source_add_uri_targets();
             handler_ids
                 .lock()
                 .unwrap()
                 .push(window.connect_drag_data_get(move |_, _, data, _, _| {
+                    println!("Preparing URIs for drag data");
                     let uris: Vec<String> = paths
                         .iter()
                         .map(|path| format!("file://{}", path.display()))
                         .collect();
                     let uris: Vec<&str> = uris.iter().map(|s| s.as_str()).collect();
+                    println!("Setting URIs: {:?}", uris);
                     data.set_uris(&uris);
                 }));
         }
         DragItem::Data { .. } => {
-            // Currently leaving it as is as we can utilize it as a dummy dragging feature
-            // on_drop_callback(DragResult::Cancel, get_cursor_position(window).unwrap());
-            // return Ok(());
+            println!("Data drag type currently not fully implemented");
         }
     }
 
     if let Some(target_list) = &window.drag_source_get_target_list() {
+        println!("Got target list, initiating drag");
         if let Some(drag_context) = window.drag_begin_with_coordinates(
             target_list,
             drag_action,
@@ -64,44 +69,55 @@ pub fn start_drag<F: Fn(DragResult, CursorPosition) + Send + 'static>(
             -1,
             -1,
         ) {
+            println!("Drag context created successfully");
             let callback = Rc::new(on_drop_callback);
             on_drop_failed(callback.clone(), window, &handler_ids, &options);
             on_drop_performed(callback.clone(), window, &handler_ids, &drag_context);
 
+            println!("Setting up drag icon");
             let icon_pixbuf: Option<gdk_pixbuf::Pixbuf> = match &image {
-                Image::Raw(data) => image_binary_to_pixbuf(data),
-                Image::File(path) => match std::fs::read(path) {
-                    Ok(bytes) => image_binary_to_pixbuf(&bytes),
-                    Err(_) => None,
-                },
+                Image::Raw(data) => {
+                    println!("Using raw image data for icon");
+                    image_binary_to_pixbuf(data)
+                }
+                Image::File(path) => {
+                    println!("Loading icon from file: {:?}", path);
+                    match std::fs::read(path) {
+                        Ok(bytes) => image_binary_to_pixbuf(&bytes),
+                        Err(e) => {
+                            println!("Failed to read icon file: {:?}", e);
+                            None
+                        }
+                    }
+                }
             };
             if let Some(icon) = icon_pixbuf {
+                println!("Setting drag icon");
                 drag_context.drag_set_icon_pixbuf(&icon, 0, 0);
+            } else {
+                println!("No icon available for drag operation");
             }
 
             Ok(())
         } else {
+            println!("Failed to create drag context");
             Err(crate::Error::FailedToStartDrag)
         }
     } else {
+        println!("No target list available");
         Err(crate::Error::EmptyTargetList)
     }
 }
 
-fn image_binary_to_pixbuf(data: &[u8]) -> Option<gdk_pixbuf::Pixbuf> {
-    let loader = gdk_pixbuf::PixbufLoader::new();
-    loader
-        .write(data)
-        .and_then(|_| loader.close())
-        .map_err(|_| ())
-        .and_then(|_| loader.pixbuf().ok_or(()))
-        .ok()
-}
-
-fn clear_signal_handlers(window: &gtk::ApplicationWindow, handler_ids: &mut Vec<SignalHandlerId>) {
-    for handler_id in handler_ids.drain(..) {
-        window.disconnect(handler_id);
-    }
+fn cleanup_signal_handlers(
+    handler_ids: &Arc<Mutex<Vec<SignalHandlerId>>>,
+    window: &gtk::ApplicationWindow,
+) {
+    println!("Cleaning up signal handlers");
+    let handler_ids = &mut handler_ids.lock().unwrap();
+    clear_signal_handlers(window, handler_ids);
+    window.drag_source_unset();
+    println!("Signal handlers cleaned up");
 }
 
 fn on_drop_failed<F: Fn(DragResult, CursorPosition) + Send + 'static>(
@@ -110,6 +126,7 @@ fn on_drop_failed<F: Fn(DragResult, CursorPosition) + Send + 'static>(
     handler_ids: &Arc<Mutex<Vec<SignalHandlerId>>>,
     options: &Options,
 ) {
+    println!("Setting up drop failed handler");
     let window_clone = window.clone();
     let handler_ids_clone = handler_ids.clone();
 
@@ -119,6 +136,7 @@ fn on_drop_failed<F: Fn(DragResult, CursorPosition) + Send + 'static>(
         .lock()
         .unwrap()
         .push(window.connect_drag_failed(move |_, _, _drag_result| {
+            println!("Drag failed or cancelled");
             callback(
                 DragResult::Cancel,
                 get_cursor_position(&window_clone).unwrap(),
@@ -126,20 +144,13 @@ fn on_drop_failed<F: Fn(DragResult, CursorPosition) + Send + 'static>(
 
             cleanup_signal_handlers(&handler_ids_clone, &window_clone);
             if skip_animatation_on_cancel_or_failure {
+                println!("Skipping animation on cancel");
                 Propagation::Stop
             } else {
+                println!("Proceeding with default animation");
                 Propagation::Proceed
             }
         }));
-}
-
-fn cleanup_signal_handlers(
-    handler_ids: &Arc<Mutex<Vec<SignalHandlerId>>>,
-    window: &gtk::ApplicationWindow,
-) {
-    let handler_ids = &mut handler_ids.lock().unwrap();
-    clear_signal_handlers(window, handler_ids);
-    window.drag_source_unset();
 }
 
 fn on_drop_performed<F: Fn(DragResult, CursorPosition) + Send + 'static>(
@@ -148,24 +159,29 @@ fn on_drop_performed<F: Fn(DragResult, CursorPosition) + Send + 'static>(
     handler_ids: &Arc<Mutex<Vec<SignalHandlerId>>>,
     drag_context: &gdk::DragContext,
 ) {
+    println!("Setting up drop performed handler");
     let window = window.clone();
     let handler_ids = handler_ids.clone();
 
     drag_context.connect_drop_performed(move |_, _| {
+        println!("Drop performed successfully");
         cleanup_signal_handlers(&handler_ids, &window);
         callback(DragResult::Dropped, get_cursor_position(&window).unwrap());
     });
 }
 
 fn get_cursor_position(window: &gtk::ApplicationWindow) -> Result<CursorPosition, Error> {
+    println!("Getting cursor position");
     if let Some(cursor) = window
         .display()
         .default_seat()
         .and_then(|seat| seat.pointer())
     {
         let (_, x, y) = cursor.position();
+        println!("Cursor position: x={}, y={}", x, y);
         Ok(CursorPosition { x, y })
     } else {
+        println!("Failed to get cursor position");
         Err(Error::FailedToGetCursorPosition)
     }
 }

--- a/crates/drag/src/platform_impl/gtk/mod.rs
+++ b/crates/drag/src/platform_impl/gtk/mod.rs
@@ -26,7 +26,6 @@ pub fn start_drag<F: Fn(DragResult, CursorPosition) + Send + 'static>(
     options: Options,
 ) -> crate::Result<()> {
     println!("Starting drag operation with mode: {:?}", options.mode);
-
     let handler_ids: Arc<Mutex<Vec<SignalHandlerId>>> = Arc::new(Mutex::new(vec![]));
     let drag_action = match options.mode {
         DragMode::Copy => gdk::DragAction::COPY,
@@ -37,7 +36,7 @@ pub fn start_drag<F: Fn(DragResult, CursorPosition) + Send + 'static>(
     window.drag_source_set(gdk::ModifierType::BUTTON1_MASK, &[], drag_action);
 
     match item {
-        DragItem::Files(ref paths) => {
+        DragItem::Files(paths) => {
             println!("Setting up file drag with {} paths", paths.len());
             window.drag_source_add_uri_targets();
             handler_ids
@@ -55,7 +54,9 @@ pub fn start_drag<F: Fn(DragResult, CursorPosition) + Send + 'static>(
                 }));
         }
         DragItem::Data { .. } => {
-            println!("Data drag type currently not fully implemented");
+            // Currently leaving it as is as we can utilize it as a dummy dragging feature
+            // on_drop_callback(DragResult::Cancel, get_cursor_position(window).unwrap());
+            // return Ok(());
         }
     }
 
@@ -76,48 +77,39 @@ pub fn start_drag<F: Fn(DragResult, CursorPosition) + Send + 'static>(
 
             println!("Setting up drag icon");
             let icon_pixbuf: Option<gdk_pixbuf::Pixbuf> = match &image {
-                Image::Raw(data) => {
-                    println!("Using raw image data for icon");
-                    image_binary_to_pixbuf(data)
-                }
-                Image::File(path) => {
-                    println!("Loading icon from file: {:?}", path);
-                    match std::fs::read(path) {
-                        Ok(bytes) => image_binary_to_pixbuf(&bytes),
-                        Err(e) => {
-                            println!("Failed to read icon file: {:?}", e);
-                            None
-                        }
-                    }
-                }
+                Image::Raw(data) => image_binary_to_pixbuf(data),
+                Image::File(path) => match std::fs::read(path) {
+                    Ok(bytes) => image_binary_to_pixbuf(&bytes),
+                    Err(_) => None,
+                },
             };
             if let Some(icon) = icon_pixbuf {
-                println!("Setting drag icon");
                 drag_context.drag_set_icon_pixbuf(&icon, 0, 0);
-            } else {
-                println!("No icon available for drag operation");
             }
 
             Ok(())
         } else {
-            println!("Failed to create drag context");
             Err(crate::Error::FailedToStartDrag)
         }
     } else {
-        println!("No target list available");
         Err(crate::Error::EmptyTargetList)
     }
 }
 
-fn cleanup_signal_handlers(
-    handler_ids: &Arc<Mutex<Vec<SignalHandlerId>>>,
-    window: &gtk::ApplicationWindow,
-) {
-    println!("Cleaning up signal handlers");
-    let handler_ids = &mut handler_ids.lock().unwrap();
-    clear_signal_handlers(window, handler_ids);
-    window.drag_source_unset();
-    println!("Signal handlers cleaned up");
+fn image_binary_to_pixbuf(data: &[u8]) -> Option<gdk_pixbuf::Pixbuf> {
+    let loader = gdk_pixbuf::PixbufLoader::new();
+    loader
+        .write(data)
+        .and_then(|_| loader.close())
+        .map_err(|_| ())
+        .and_then(|_| loader.pixbuf().ok_or(()))
+        .ok()
+}
+
+fn clear_signal_handlers(window: &gtk::ApplicationWindow, handler_ids: &mut Vec<SignalHandlerId>) {
+    for handler_id in handler_ids.drain(..) {
+        window.disconnect(handler_id);
+    }
 }
 
 fn on_drop_failed<F: Fn(DragResult, CursorPosition) + Send + 'static>(
@@ -144,13 +136,22 @@ fn on_drop_failed<F: Fn(DragResult, CursorPosition) + Send + 'static>(
 
             cleanup_signal_handlers(&handler_ids_clone, &window_clone);
             if skip_animatation_on_cancel_or_failure {
-                println!("Skipping animation on cancel");
                 Propagation::Stop
             } else {
-                println!("Proceeding with default animation");
                 Propagation::Proceed
             }
         }));
+}
+
+fn cleanup_signal_handlers(
+    handler_ids: &Arc<Mutex<Vec<SignalHandlerId>>>,
+    window: &gtk::ApplicationWindow,
+) {
+    println!("Cleaning up signal handlers");
+    let handler_ids = &mut handler_ids.lock().unwrap();
+    clear_signal_handlers(window, handler_ids);
+    window.drag_source_unset();
+    println!("Signal handlers cleaned up");
 }
 
 fn on_drop_performed<F: Fn(DragResult, CursorPosition) + Send + 'static>(
@@ -171,17 +172,14 @@ fn on_drop_performed<F: Fn(DragResult, CursorPosition) + Send + 'static>(
 }
 
 fn get_cursor_position(window: &gtk::ApplicationWindow) -> Result<CursorPosition, Error> {
-    println!("Getting cursor position");
     if let Some(cursor) = window
         .display()
         .default_seat()
         .and_then(|seat| seat.pointer())
     {
         let (_, x, y) = cursor.position();
-        println!("Cursor position: x={}, y={}", x, y);
         Ok(CursorPosition { x, y })
     } else {
-        println!("Failed to get cursor position");
         Err(Error::FailedToGetCursorPosition)
     }
 }

--- a/crates/drag/src/platform_impl/macos/mod.rs
+++ b/crates/drag/src/platform_impl/macos/mod.rs
@@ -234,9 +234,10 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
                             let mode = *this.get_ivar::<DragMode>("drag_mode");
                             let () = msg_send![dragging_session, setAnimatesToStartingPositionsOnCancelOrFail: *animates];
 
+                            // Let the system decide based on volume/destination
                             match mode {
-                                DragMode::Copy => 1,  // NSDragOperationCopy
-                                DragMode::Move => 16, // NSDragOperationMove
+                                DragMode::Move => NSUInteger::MAX, // Allow all operations
+                                DragMode::Copy => 1,               // Force copy
                                 DragMode::Smart => {
                                     if context == 0 {
                                         1 // Local context: Copy

--- a/crates/drag/src/platform_impl/macos/mod.rs
+++ b/crates/drag/src/platform_impl/macos/mod.rs
@@ -234,10 +234,9 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
                             let mode = *this.get_ivar::<DragMode>("drag_mode");
                             let () = msg_send![dragging_session, setAnimatesToStartingPositionsOnCancelOrFail: *animates];
 
-                            // Let the system decide based on volume/destination
                             match mode {
-                                DragMode::Move => NSUInteger::MAX, // Allow all operations
-                                DragMode::Copy => 1,               // Force copy
+                                DragMode::Copy => 1,  // NSDragOperationCopy
+                                DragMode::Move => 16, // NSDragOperationMove
                                 DragMode::Smart => {
                                     if context == 0 {
                                         1 // Local context: Copy

--- a/crates/drag/src/platform_impl/macos/mod.rs
+++ b/crates/drag/src/platform_impl/macos/mod.rs
@@ -51,13 +51,13 @@ impl NSString {
 }
 
 pub struct DragSession {
-    ns_view: id,
+    dragging_session: id,
 }
 
 impl DragSession {
     pub fn cancel(&self) {
         unsafe {
-            let _: () = msg_send![self.ns_view, concludeDragOperation];
+            let _: () = msg_send![self.dragging_session, endDraggingSession];
         }
     }
 }
@@ -300,9 +300,9 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
             );
             (*source).set_ivar("drag_mode", options.mode);
 
-            let _: () = msg_send![ns_view, beginDraggingSessionWithItems: dragging_items event: drag_event source: source];
+            let dragging_session: id = msg_send![ns_view, beginDraggingSessionWithItems: dragging_items event: drag_event source: source];
 
-            Ok(DragSession { ns_view })
+            Ok(DragSession { dragging_session })
         }
     } else {
         Err(crate::Error::UnsupportedWindowHandle)

--- a/crates/drag/src/platform_impl/macos/mod.rs
+++ b/crates/drag/src/platform_impl/macos/mod.rs
@@ -235,15 +235,9 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
                             let () = msg_send![dragging_session, setAnimatesToStartingPositionsOnCancelOrFail: *animates];
 
                             match mode {
-                                DragMode::Copy => 1,  // NSDragOperationCopy
-                                DragMode::Move => 16, // NSDragOperationMove
-                                DragMode::Smart => {
-                                    if context == 0 {
-                                        1 // Local context: Copy
-                                    } else {
-                                        NSUInteger::MAX // External context: All operations
-                                    }
-                                }
+                                DragMode::Copy => 1,   // NSDragOperationCopy
+                                DragMode::Move => 16,  // NSDragOperationMove
+                                DragMode::Smart => 17, // NSDragOperationMove | NSDragOperationCopy
                             }
                         }
                     }

--- a/crates/drag/src/platform_impl/macos/mod.rs
+++ b/crates/drag/src/platform_impl/macos/mod.rs
@@ -251,12 +251,13 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
                     extern "C" fn dragging_session_end(
                         this: &Object,
                         _: Sel,
-                        _dragging_session: id,
+                        dragging_session: id,
                         ended_at_point: NSPoint,
                         operation: NSUInteger,
                     ) {
                         unsafe {
                             let callback = this.get_ivar::<*mut c_void>("on_drop_ptr");
+                            let mode = *this.get_ivar::<DragMode>("drag_mode");
 
                             let mouse_location = CursorPosition {
                                 x: ended_at_point.x as i32,
@@ -270,10 +271,19 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
                                 // NSDragOperationNone
                                 callback_closure(DragResult::Cancel, mouse_location);
                             } else {
+                                // For Smart mode, if move operation failed, fall back to copy
+                                if matches!(mode, DragMode::Smart) && operation != 16 {
+                                    let pasteboard: id =
+                                        msg_send![dragging_session, draggingPasteboard];
+                                    let _: () = msg_send![pasteboard, setOperationMask:1];
+                                    // Force copy operation
+                                }
                                 callback_closure(DragResult::Dropped, mouse_location);
                             }
 
-                            drop(Box::from_raw(*callback as *mut Box<dyn Fn(DragResult)>));
+                            drop(Box::from_raw(
+                                *callback as *mut Box<dyn Fn(DragResult, CursorPosition)>,
+                            ));
                         }
                     }
 

--- a/crates/drag/src/platform_impl/macos/mod.rs
+++ b/crates/drag/src/platform_impl/macos/mod.rs
@@ -291,7 +291,7 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
             );
             (*source).set_ivar("drag_mode", options.mode);
 
-            let _: id = msg_send![ns_view, beginDraggingSessionWithItems: dragging_items event: drag_event source: source];
+            let _: () = msg_send![ns_view, beginDraggingSessionWithItems: dragging_items event: drag_event source: source];
 
             Ok(())
         }

--- a/crates/drag/src/platform_impl/macos/mod.rs
+++ b/crates/drag/src/platform_impl/macos/mod.rs
@@ -317,3 +317,7 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
         Err(crate::Error::UnsupportedWindowHandle)
     }
 }
+
+pub fn cancel_drag() {
+    SHOULD_CANCEL_DRAG.store(true, Ordering::SeqCst);
+}

--- a/crates/drag/src/platform_impl/macos/mod.rs
+++ b/crates/drag/src/platform_impl/macos/mod.rs
@@ -105,10 +105,8 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
                         let item: id = msg_send![drag_item, initWithPasteboardWriter: nsurl];
 
                         let _: () = msg_send![item, setDraggingFrame: image_rect contents: img];
-                        print!("[drag -> debug] dragging file: {:?}", path);
 
                         let _: () = msg_send![dragging_items, addObject: item];
-                        println!("[drag -> debug] ....done");
                     }
                 }
                 DragItem::Data { provider, types } => {
@@ -238,7 +236,6 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
                             let animates = this.get_ivar::<BOOL>("animate_on_cancel_or_failure");
                             let mode = *this.get_ivar::<DragMode>("drag_mode");
                             let () = msg_send![dragging_session, setAnimatesToStartingPositionsOnCancelOrFail: *animates];
-                            println!("[drag -> debug] dragging session: {:?}", mode);
 
                             match mode {
                                 DragMode::Copy => 1,  // NSDragOperationCopy
@@ -264,11 +261,7 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
 
                             let callback_closure =
                                 &*(*callback as *mut Box<dyn Fn(DragResult, CursorPosition)>);
-                            println!(
-                                "[drag -> debug] dragging session end: {:?} {:?}",
-                                operation, mouse_location
-                            );
-
+                                
                             if operation == 0 {
                                 // NSDragOperationNone
                                 callback_closure(DragResult::Cancel, mouse_location);

--- a/crates/drag/src/platform_impl/macos/mod.rs
+++ b/crates/drag/src/platform_impl/macos/mod.rs
@@ -105,8 +105,10 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
                         let item: id = msg_send![drag_item, initWithPasteboardWriter: nsurl];
 
                         let _: () = msg_send![item, setDraggingFrame: image_rect contents: img];
+                        print!("[drag -> debug] dragging file: {:?}", path);
 
                         let _: () = msg_send![dragging_items, addObject: item];
+                        println!("[drag -> debug] ....done");
                     }
                 }
                 DragItem::Data { provider, types } => {
@@ -236,6 +238,7 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
                             let animates = this.get_ivar::<BOOL>("animate_on_cancel_or_failure");
                             let mode = *this.get_ivar::<DragMode>("drag_mode");
                             let () = msg_send![dragging_session, setAnimatesToStartingPositionsOnCancelOrFail: *animates];
+                            println!("[drag -> debug] dragging session: {:?}", mode);
 
                             match mode {
                                 DragMode::Copy => 1,  // NSDragOperationCopy
@@ -261,6 +264,10 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
 
                             let callback_closure =
                                 &*(*callback as *mut Box<dyn Fn(DragResult, CursorPosition)>);
+                            println!(
+                                "[drag -> debug] dragging session end: {:?} {:?}",
+                                operation, mouse_location
+                            );
 
                             if operation == 0 {
                                 // NSDragOperationNone

--- a/crates/drag/src/platform_impl/mod.rs
+++ b/crates/drag/src/platform_impl/mod.rs
@@ -11,6 +11,4 @@ mod platform;
 #[cfg(target_os = "macos")]
 #[path = "macos/mod.rs"]
 mod platform;
-
-pub use platform::cancel_drag;
 pub use platform::start_drag;

--- a/crates/drag/src/platform_impl/mod.rs
+++ b/crates/drag/src/platform_impl/mod.rs
@@ -12,4 +12,5 @@ mod platform;
 #[path = "macos/mod.rs"]
 mod platform;
 
+pub use platform::cancel_drag;
 pub use platform::start_drag;

--- a/crates/drag/src/platform_impl/windows/mod.rs
+++ b/crates/drag/src/platform_impl/windows/mod.rs
@@ -4,7 +4,7 @@
 
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
-use crate::{CursorPosition, DragItem, DragResult, Image, Options};
+use crate::{CursorPosition, DragItem, DragMode, DragResult, Image, Options};
 
 use std::{
     ffi::c_void,

--- a/crates/drag/src/platform_impl/windows/mod.rs
+++ b/crates/drag/src/platform_impl/windows/mod.rs
@@ -217,7 +217,7 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
     item: DragItem,
     image: Image,
     on_drop_callback: F,
-    _options: Options,
+    options: Options,
 ) -> crate::Result<()> {
     if let Ok(RawWindowHandle::Win32(_w)) = handle.window_handle().map(|h| h.as_raw()) {
         match item {

--- a/crates/tauri-plugin-drag-as-window/src/commands.rs
+++ b/crates/tauri-plugin-drag-as-window/src/commands.rs
@@ -167,6 +167,7 @@ fn perform_drag<R: Runtime, F: Fn() + Send + Sync + 'static>(
                 },
                 drag::Options {
                     skip_animatation_on_cancel_or_failure: true,
+                    ..Default::default()
                 },
             )
             .map_err(Into::into),


### PR DESCRIPTION
This PR introduces file move operations alongside the existing copy functionality. The implementation adds a new `DragMode` enum that allows applications to specify whether files should be copied or moved during drag operations.

## Changes
- Added `DragMode` enum with `Copy` and `Move` variants
- Implemented platform-specific move operations for:
  - macOS using `NSDragOperationMove`
  - Windows using `DROPEFFECT_MOVE`
  - Linux/GTK using `gdk::DragAction::MOVE`
- Extended `Options` struct to include `mode` field with `DragMode::Copy` as default
- Maintained backward compatibility by defaulting to copy operations

## Use Case
This enhancement is particularly valuable for file management applications like [Spacedrive](https://github.com/spacedriveapp/spacedrive), which require copy and move capabilities when dragging files to different locations in the operating system.

## Testing Status
- Fully tested on macOS with both copy and move operations
- Implementation ready for Windows and Linux based on platform documentation
- Seeking community testing and feedback for Windows and Linux platforms