### PR TITLE
fix: workaround for crash on certain MacOS systems

### DIFF
--- a/.changes/fix-drag-crash-intel.md
+++ b/.changes/fix-drag-crash-intel.md
@@ -1,0 +1,5 @@
+---
+"drag": patch
+---
+
+Fix crash on macOS systems running Intel or older macOS releases.

--- a/crates/drag/src/platform_impl/macos/mod.rs
+++ b/crates/drag/src/platform_impl/macos/mod.rs
@@ -63,7 +63,7 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
             // wry replaces the ns_view so we don't really use AppKitWindowHandle::ns_view
             let ns_view: id = msg_send![window, contentView];
 
-            let current_position = NSPoint::new(0., 0.);
+            let current_position: NSPoint = msg_send![window, mouseLocationOutsideOfEventStream];
 
             let img: id = msg_send![class!(NSImage), alloc];
             let img: id = match image {

--- a/crates/drag/src/platform_impl/macos/mod.rs
+++ b/crates/drag/src/platform_impl/macos/mod.rs
@@ -5,7 +5,7 @@
 use std::ffi::{c_char, c_void};
 
 use cocoa::{
-    appkit::{NSAlignmentOptions, NSApp, NSEvent, NSEventModifierFlags, NSEventType, NSImage},
+    appkit::{NSApp, NSEvent, NSEventModifierFlags, NSEventType, NSImage},
     base::{id, nil},
     foundation::{NSArray, NSData, NSPoint, NSRect, NSSize, NSUInteger},
 };

--- a/crates/drag/src/platform_impl/macos/mod.rs
+++ b/crates/drag/src/platform_impl/macos/mod.rs
@@ -55,7 +55,7 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
     item: DragItem,
     image: Image,
     on_drop_callback: F,
-    options: Options,
+    _options: Options,
 ) -> crate::Result<()> {
     if let Ok(RawWindowHandle::AppKit(w)) = handle.window_handle().map(|h| h.as_raw()) {
         unsafe {
@@ -63,8 +63,7 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
             // wry replaces the ns_view so we don't really use AppKitWindowHandle::ns_view
             let ns_view: id = msg_send![window, contentView];
 
-            let mouse_location: NSPoint = msg_send![window, mouseLocationOutsideOfEventStream];
-            let current_position: NSPoint = msg_send![ns_view, backingAlignedRect: NSRect::new(mouse_location, NSSize::new(0., 0.)) options: NSAlignmentOptions::NSAlignAllEdgesOutward];
+            let current_position = NSPoint::new(0., 0.);
 
             let img: id = msg_send![class!(NSImage), alloc];
             let img: id = match image {
@@ -283,10 +282,6 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
                 Box::new(on_drop_callback) as Box<dyn Fn(DragResult, CursorPosition) + Send>;
             let callback_ptr = Box::into_raw(Box::new(on_drop_callback));
             (*source).set_ivar("on_drop_ptr", callback_ptr as *mut _ as *mut c_void);
-            (*source).set_ivar(
-                "animate_on_cancel_or_failure",
-                !options.skip_animatation_on_cancel_or_failure,
-            );
 
             let _: () = msg_send![ns_view, beginDraggingSessionWithItems: dragging_items event: drag_event source: source];
         }

--- a/crates/drag/src/platform_impl/macos/mod.rs
+++ b/crates/drag/src/platform_impl/macos/mod.rs
@@ -55,7 +55,7 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
     item: DragItem,
     image: Image,
     on_drop_callback: F,
-    _options: Options,
+    options: Options,
 ) -> crate::Result<()> {
     if let Ok(RawWindowHandle::AppKit(w)) = handle.window_handle().map(|h| h.as_raw()) {
         unsafe {
@@ -282,6 +282,14 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
                 Box::new(on_drop_callback) as Box<dyn Fn(DragResult, CursorPosition) + Send>;
             let callback_ptr = Box::into_raw(Box::new(on_drop_callback));
             (*source).set_ivar("on_drop_ptr", callback_ptr as *mut _ as *mut c_void);
+            (*source).set_ivar(
+                "animate_on_cancel_or_failure",
+                if options.skip_animatation_on_cancel_or_failure {
+                    YES
+                } else {
+                    NO
+                },
+            );
 
             let _: () = msg_send![ns_view, beginDraggingSessionWithItems: dragging_items event: drag_event source: source];
         }


### PR DESCRIPTION
Workaround for #23 .

I don't believe this is the proper fix, but this is the best I could find to make it work on my OS.

I don't see any obvious regressions although one time I saw that when I started dragging the icon appeared on the top-left corner of my screen and immediately jumped to my mouse. I believe this may be related to my change but I was not able to reproduce it again.


https://github.com/user-attachments/assets/6ab9195b-d14f-4495-aa8a-8770212eab33


Original behavior:

https://github.com/user-attachments/assets/2e505e8d-8901-45fe-9e40-d4584332e4ab


