### PR TITLE
Allow non exact versions of raw_window_handle

### DIFF
--- a/.changes/rwh-min-ver.md
+++ b/.changes/rwh-min-ver.md
@@ -1,0 +1,5 @@
+---
+drag: patch
+---
+
+Changed the minimum version of the `raw-window-handle` rust crate from `0.6.2` to `0.6.0`.

--- a/crates/drag/Cargo.toml
+++ b/crates/drag/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
-raw-window-handle = "^0.6.0"
+raw-window-handle = "0.6"
 thiserror.workspace = true
 serde = { workspace = true, optional = true }
 log = "0.4"

--- a/crates/drag/Cargo.toml
+++ b/crates/drag/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
-raw-window-handle = "0.6.2"
+raw-window-handle = "^0.6.0"
 thiserror.workspace = true
 serde = { workspace = true, optional = true }
 log = "0.4"


### PR DESCRIPTION
The sdl2 crate still uses version 0.6.0 so this caused me a bit of trouble. Versions before that don't have the `as_raw` function so I think 0.6.0 is the lowest it can go without having to change the code.