### PR TITLE
enhance error handling for drag operations

### DIFF
--- a/crates/drag/src/lib.rs
+++ b/crates/drag/src/lib.rs
@@ -93,6 +93,9 @@ pub enum Error {
     #[cfg(windows)]
     #[error("{0}")]
     WindowsError(#[from] windows::core::Error),
+    #[cfg(windows)]
+    #[error("failed to resolve path for drag operation: {0}")]
+    InvalidShellPath(std::path::PathBuf),
     #[error(transparent)]
     Io(#[from] std::io::Error),
     #[error("unsupported window handle")]

--- a/crates/drag/src/platform_impl/windows/mod.rs
+++ b/crates/drag/src/platform_impl/windows/mod.rs
@@ -235,7 +235,7 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
                     paths.push(dunce::canonicalize(f)?);
                 }
 
-                let data_object: IDataObject = get_file_data_object(&paths).unwrap();
+                let data_object: IDataObject = get_file_data_object(&paths)?;
                 let drop_source: IDropSource = DropSource::new().into();
 
                 unsafe {
@@ -276,7 +276,7 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
 
                 let paths = vec![dunce::canonicalize("./")?];
 
-                let data_object: IDataObject = get_file_data_object(&paths).unwrap();
+                let data_object: IDataObject = get_file_data_object(&paths)?;
                 let drop_source: IDropSource = DummyDropSource::new().into();
 
                 unsafe {
@@ -365,26 +365,84 @@ pub fn create_instance<T: Interface + ComInterface>(clsid: &GUID) -> Result<T> {
     unsafe { CoCreateInstance(clsid, None, CLSCTX_ALL) }
 }
 
-fn get_file_data_object(paths: &[PathBuf]) -> Option<IDataObject> {
+fn get_file_data_object(paths: &[PathBuf]) -> crate::Result<IDataObject> {
     unsafe {
-        let shell_item_array = get_shell_item_array(paths).unwrap();
-        shell_item_array.BindToHandler(None, &BHID_DataObject).ok()
+        let shell_item_array = get_shell_item_array(paths)?;
+        Ok(shell_item_array.BindToHandler(None, &BHID_DataObject)?)
     }
 }
 
-fn get_shell_item_array(paths: &[PathBuf]) -> Option<IShellItemArray> {
+fn get_shell_item_array(paths: &[PathBuf]) -> crate::Result<IShellItemArray> {
     unsafe {
-        let list: Vec<*const Common::ITEMIDLIST> = paths
-            .iter()
-            .map(|path| get_file_item_id(path).cast_const())
-            .collect();
-        SHCreateShellItemArrayFromIDLists(&list).ok()
+        let mut list: Vec<*const Common::ITEMIDLIST> = Vec::with_capacity(paths.len());
+        for path in paths {
+            match get_file_item_id(path) {
+                Ok(pidl) => list.push(pidl.cast_const()),
+                Err(e) => {
+                    for pidl in &list {
+                        CoTaskMemFree(Some(*pidl as *const _ as *mut _));
+                    }
+                    return Err(e);
+                }
+            }
+        }
+        let result = SHCreateShellItemArrayFromIDLists(&list);
+        for pidl in &list {
+            CoTaskMemFree(Some(*pidl as *const _ as *mut _));
+        }
+        Ok(result?)
     }
 }
 
-fn get_file_item_id(path: &Path) -> *mut Common::ITEMIDLIST {
+fn get_file_item_id(path: &Path) -> crate::Result<*mut Common::ITEMIDLIST> {
     unsafe {
         let wide_path: Vec<u16> = path.as_os_str().encode_wide().chain(once(0)).collect();
-        windows::Win32::UI::Shell::ILCreateFromPathW(PCWSTR::from_raw(wide_path.as_ptr()))
+        let pidl =
+            windows::Win32::UI::Shell::ILCreateFromPathW(PCWSTR::from_raw(wide_path.as_ptr()));
+        if pidl.is_null() {
+            Err(crate::Error::InvalidShellPath(path.to_path_buf()))
+        } else {
+            Ok(pidl)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_file_item_id_returns_error_for_nonexistent_path() {
+        let path = PathBuf::from(r"C:\__nonexistent_drag_rs_test_path__\file.txt");
+        let result = get_file_item_id(&path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn get_file_item_id_returns_error_for_unc_nonexistent() {
+        let path = PathBuf::from(r"\\nonexistent_server_drag_rs\share\file.png");
+        let result = get_file_item_id(&path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn get_shell_item_array_returns_error_for_invalid_paths() {
+        let paths = vec![PathBuf::from(r"C:\__nonexistent_drag_rs_test__\a.txt")];
+        let result = get_shell_item_array(&paths);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn get_file_data_object_returns_error_not_panic_for_bad_paths() {
+        let paths = vec![PathBuf::from(r"\\nonexistent_server\share\file.png")];
+        let result = get_file_data_object(&paths);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn get_file_item_id_succeeds_for_existing_file() {
+        let path = PathBuf::from(r"C:\Windows\System32\notepad.exe");
+        let result = get_file_item_id(&path);
+        assert!(result.is_ok());
     }
 }


### PR DESCRIPTION
This pull request improves error handling and robustness in the Windows drag-and-drop implementation by replacing panics and unwraps with proper error propagation. It introduces a new error variant for invalid shell paths, updates several internal functions to return results instead of options, and adds comprehensive tests to ensure correct error handling for invalid paths.

Written to mitigate https://github.com/crabnebula-dev/drag-rs/issues/72

This doesn't solve the UNC security issue, but at least least lets the app's manage the error without crashing.

**Error handling improvements:**

* Added a new error variant `InvalidShellPath` to the `Error` enum to represent failures when resolving shell paths during drag operations.
* Updated `get_file_data_object`, `get_shell_item_array`, and `get_file_item_id` to return `Result` types and propagate errors instead of panicking or unwrapping, ensuring safer error handling throughout the drag-and-drop code path.
* Modified `start_drag` to propagate errors from `get_file_data_object` instead of using `unwrap`, preventing panics during drag operations with invalid paths. [[1]](diffhunk://#diff-9f099ef8af3eab330e0e3c35afba6af39ad7d585a6393db3c1826cb909a07e57L238-R238) [[2]](diffhunk://#diff-9f099ef8af3eab330e0e3c35afba6af39ad7d585a6393db3c1826cb909a07e57L279-R279)

**Testing and validation:**

* Added unit tests for `get_file_item_id`, `get_shell_item_array`, and `get_file_data_object` to verify correct error handling for non-existent and invalid paths, increasing code robustness.