### PR TITLE
feat: carry the drop-operation negotiation in both directions

### DIFF
--- a/.changes/drop-operation-negotiation.md
+++ b/.changes/drop-operation-negotiation.md
@@ -1,0 +1,26 @@
+---
+"drag": major
+"tauri-plugin-drag": major
+"tauri-plugin-drag-as-window": major
+"@crabnebula/tauri-plugin-drag": major
+"@crabnebula/tauri-plugin-drag-as-window": major
+---
+
+Carry the drag-and-drop negotiation in both directions:
+
+- `DragResult::Dropped` now carries a `DropOperation` — a portable bit mask
+  (`COPY | MOVE | LINK`) reporting the operation the drop target actually
+  negotiated, normalized from `DoDragDrop`'s out `DROPEFFECT` (Windows),
+  the `draggingSession:endedAtPoint:operation:` argument (macOS), and the
+  drag context's `selected_action` (GTK). With the `serde` feature the wire
+  form of `Dropped` changes from `"Dropped"` to `{"Dropped": <mask>}`; the
+  TypeScript `DragResult` types are updated to match (they previously also
+  never matched the `Cancel` arm).
+- `Options.mode: DragMode` is replaced by `Options.allowed_operations:
+  DropOperation`, the mask of operations the source permits the target to
+  negotiate, feeding `dwOKEffects` (Windows), the
+  `sourceOperationMaskForDraggingContext:` return (macOS) and the source's
+  `GdkDragAction` (GTK). `Options::default()` still permits exactly a copy.
+  An empty mask now makes the drag undroppable instead of silently offering
+  a copy. The plugins' `mode` option accepts `"link"` in addition to
+  `"copy"` and `"move"`.

--- a/crates/drag/Cargo.toml
+++ b/crates/drag/Cargo.toml
@@ -17,7 +17,7 @@ tao.workspace = true
 winit.workspace = true
 wry.workspace = true
 tauri.workspace = true
-serde_json = "1"
+serde_json.workspace = true
 
 [target."cfg(target_os = \"macos\")".dependencies]
 objc2 = "0.6.4"

--- a/crates/drag/Cargo.toml
+++ b/crates/drag/Cargo.toml
@@ -17,6 +17,7 @@ tao.workspace = true
 winit.workspace = true
 wry.workspace = true
 tauri.workspace = true
+serde_json = "1"
 
 [target."cfg(target_os = \"macos\")".dependencies]
 objc2 = "0.6.4"

--- a/crates/drag/src/lib.rs
+++ b/crates/drag/src/lib.rs
@@ -113,8 +113,124 @@ pub enum Error {
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum DragResult {
-    Dropped,
+    /// The data was dropped on a target, which negotiated the enclosed
+    /// [`DropOperation`] — what the source must now do with the original data
+    /// (delete it after a move, leave it alone after a copy, …).
+    ///
+    /// A target that accepted the drop and then performed nothing yields an
+    /// empty mask ([`DropOperation::is_empty`]); that is still a `Dropped`,
+    /// not a `Cancel`.
+    Dropped(DropOperation),
     Cancel,
+}
+
+/// The operation a drop target negotiated for a completed drop
+/// ([`DragResult::Dropped`]).
+///
+/// A **mask**, not a single value, because two of the three platform values
+/// are masks and none of them promises a single bit:
+///
+/// - Windows: `DoDragDrop`'s out `DROPEFFECT`. Its documentation is explicit
+///   that callers must bit-test rather than compare ("Your application should
+///   always mask values from the DROPEFFECT enumeration to ensure
+///   compatibility with future implementations").
+/// - macOS: `draggingSession:endedAtPoint:operation:`'s `NSDragOperation`, an
+///   `NS_OPTIONS` bit mask.
+/// - Linux (GTK): the drag context's `selected_action`, a `GdkDragAction` bit
+///   mask.
+///
+/// The bits below are the crate's own portable set; each platform normalizes
+/// its native value into them. Platform bits with no portable counterpart are
+/// folded onto their closest neighbour, or dropped when they carry no
+/// source-side obligation:
+///
+/// | platform bit | portable bit | why |
+/// | --- | --- | --- |
+/// | `DROPEFFECT_SCROLL` | — | target-scroll feedback, not an operation |
+/// | `NSDragOperationDelete` | [`Self::MOVE`] | drag-to-Trash: the source must delete |
+/// | `NSDragOperationGeneric` | [`Self::COPY`] | unspecified accept; the source keeps its data |
+/// | `NSDragOperationPrivate` | — | receiver-internal; no source-side obligation |
+/// | `GdkDragAction::ASK` / `PRIVATE` / `DEFAULT` | — | not a settled operation |
+///
+/// [`Self::NONE`] (no bits) means the target performed nothing — ask with
+/// [`Self::is_empty`].
+///
+/// With the `serde` feature the mask is a plain `u32` on the wire, routed
+/// through [`Self::from_bits_truncate`] on the way in, so no deserialized
+/// mask can carry a bit the constructors cannot produce.
+//
+// Deliberately no `Default`: it could only be `NONE`, and `NONE` as an
+// `Options::allowed_operations` is a drag no target can accept — not a value
+// to arrive at by omitting a field. `Options` carries its own `Default`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(from = "u32", into = "u32"))]
+pub struct DropOperation(u32);
+
+impl DropOperation {
+    /// No operation was performed.
+    pub const NONE: Self = Self(0);
+    /// The target took a copy; the source data is untouched.
+    pub const COPY: Self = Self(1 << 0);
+    /// The target took the data; the source should delete the original.
+    pub const MOVE: Self = Self(1 << 1);
+    /// The target created a link to the original data.
+    pub const LINK: Self = Self(1 << 2);
+
+    /// `true` if `self` and `other` share at least one bit.
+    pub const fn intersects(self, other: Self) -> bool {
+        self.0 & other.0 != 0
+    }
+
+    /// `true` if no bits are set, i.e. the target performed nothing
+    /// ([`Self::NONE`]).
+    ///
+    /// This is the one question equality answers correctly for a mask; every
+    /// other question should go through [`Self::intersects`].
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    /// The raw bits, for consumers that keep their own mapping table.
+    pub const fn bits(self) -> u32 {
+        self.0
+    }
+
+    /// Rebuild a mask from [`Self::bits`], dropping anything that is not one
+    /// of the defined bits.
+    pub const fn from_bits_truncate(bits: u32) -> Self {
+        Self(bits & (Self::COPY.0 | Self::MOVE.0 | Self::LINK.0))
+    }
+}
+
+impl std::ops::BitOr for DropOperation {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl std::ops::BitOrAssign for DropOperation {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+/// Truncating, exactly like [`DropOperation::from_bits_truncate`]. This is
+/// also the `serde` `Deserialize` path, which keeps a wire value like
+/// `4294967295` from becoming a mask that intersects everything.
+impl From<u32> for DropOperation {
+    fn from(bits: u32) -> Self {
+        Self::from_bits_truncate(bits)
+    }
+}
+
+/// The raw bits, exactly like [`DropOperation::bits`]; the `serde`
+/// `Serialize` path — the wire form stays a bare number.
+impl From<DropOperation> for u32 {
+    fn from(operation: DropOperation) -> Self {
+        operation.bits()
+    }
 }
 
 pub type DataProvider = Box<dyn Fn(&str) -> Option<Vec<u8>>>;

--- a/crates/drag/src/lib.rs
+++ b/crates/drag/src/lib.rs
@@ -251,29 +251,29 @@ pub enum DragItem {
     },
 }
 
-#[derive(Debug, Clone, Copy, Default)]
-#[repr(u64)]
-pub enum DragMode {
-    #[default]
-    Copy = 1, // NSDragOperationCopy
-    Move = 16, // NSDragOperationMove
-}
-
-#[cfg(target_os = "macos")]
-impl From<DragMode> for objc2_app_kit::NSDragOperation {
-    fn from(value: DragMode) -> Self {
-        match value {
-            DragMode::Copy => objc2_app_kit::NSDragOperation::Copy,
-            DragMode::Move => objc2_app_kit::NSDragOperation::Move,
-        }
-    }
-}
-
-#[derive(Default)]
 pub struct Options {
     // TODO: Fix typo in v3
     pub skip_animatation_on_cancel_or_failure: bool,
-    pub mode: DragMode,
+    /// The operations this source permits the drop target to negotiate.
+    ///
+    /// Handed to the platform's own permission channel — `DoDragDrop`'s
+    /// `dwOKEffects` on Windows, the `NSDraggingSource`
+    /// `draggingSession:sourceOperationMaskForDraggingContext:` return on
+    /// macOS, the source's `GdkDragAction` on GTK. The operation the target
+    /// actually performs comes back in [`DragResult::Dropped`].
+    ///
+    /// [`DropOperation::NONE`] permits nothing, so no target can accept the
+    /// drop. The default is [`DropOperation::COPY`].
+    pub allowed_operations: DropOperation,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            skip_animatation_on_cancel_or_failure: false,
+            allowed_operations: DropOperation::COPY,
+        }
+    }
 }
 
 /// An image definition.

--- a/crates/drag/src/platform_impl/gtk/mod.rs
+++ b/crates/drag/src/platform_impl/gtk/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use crate::{CursorPosition, DragItem, DragMode, DragResult, DropOperation, Error, Image, Options};
+use crate::{CursorPosition, DragItem, DragResult, DropOperation, Error, Image, Options};
 use gdkx11::{
     gdk,
     glib::{ObjectExt, Propagation, SignalHandlerId},
@@ -25,12 +25,12 @@ pub fn start_drag<F: Fn(DragResult, CursorPosition) + Send + 'static>(
     on_drop_callback: F,
     options: Options,
 ) -> crate::Result<()> {
-    log::debug!("Starting drag operation with mode: {:?}", options.mode);
+    log::debug!(
+        "Starting drag operation, allowed operations: {:?}",
+        options.allowed_operations
+    );
     let handler_ids: Arc<Mutex<Vec<SignalHandlerId>>> = Arc::new(Mutex::new(vec![]));
-    let drag_action = match options.mode {
-        DragMode::Copy => gdk::DragAction::COPY,
-        DragMode::Move => gdk::DragAction::MOVE,
-    };
+    let drag_action = gdk_drag_action(options.allowed_operations);
 
     log::debug!("Setting drag source with action: {:?}", drag_action);
     window.drag_source_set(gdk::ModifierType::BUTTON1_MASK, &[], drag_action);
@@ -169,13 +169,29 @@ fn on_drop_performed<F: Fn(DragResult, CursorPosition) + Send + 'static>(
         log::trace!("Selected action: {:?}", context.selected_action());
         log::trace!("Suggested action: {:?}", context.suggested_action());
         cleanup_signal_handlers(&handler_ids, &window);
-        // The action the target selected is already read one line above for
-        // the trace log; carry it to the callback.
         callback(
             DragResult::Dropped(drop_operation(context.selected_action())),
             get_cursor_position(&window).unwrap(),
         );
     });
+}
+
+// The inverse of `drop_operation`: `Options::allowed_operations` → the
+// `GdkDragAction` handed to the drag source, i.e. the actions this source
+// permits. `DEFAULT`, `PRIVATE` and `ASK` are not emitted: they are
+// negotiation policy, not operations a source grants.
+fn gdk_drag_action(allowed: DropOperation) -> gdk::DragAction {
+    let mut action = gdk::DragAction::empty();
+    if allowed.intersects(DropOperation::COPY) {
+        action |= gdk::DragAction::COPY;
+    }
+    if allowed.intersects(DropOperation::MOVE) {
+        action |= gdk::DragAction::MOVE;
+    }
+    if allowed.intersects(DropOperation::LINK) {
+        action |= gdk::DragAction::LINK;
+    }
+    action
 }
 
 // The drag context's selected `GdkDragAction` → the portable `DropOperation`.

--- a/crates/drag/src/platform_impl/gtk/mod.rs
+++ b/crates/drag/src/platform_impl/gtk/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use crate::{CursorPosition, DragItem, DragMode, DragResult, Error, Image, Options};
+use crate::{CursorPosition, DragItem, DragMode, DragResult, DropOperation, Error, Image, Options};
 use gdkx11::{
     gdk,
     glib::{ObjectExt, Propagation, SignalHandlerId},
@@ -169,8 +169,32 @@ fn on_drop_performed<F: Fn(DragResult, CursorPosition) + Send + 'static>(
         log::trace!("Selected action: {:?}", context.selected_action());
         log::trace!("Suggested action: {:?}", context.suggested_action());
         cleanup_signal_handlers(&handler_ids, &window);
-        callback(DragResult::Dropped, get_cursor_position(&window).unwrap());
+        // The action the target selected is already read one line above for
+        // the trace log; carry it to the callback.
+        callback(
+            DragResult::Dropped(drop_operation(context.selected_action())),
+            get_cursor_position(&window).unwrap(),
+        );
     });
+}
+
+// The drag context's selected `GdkDragAction` → the portable `DropOperation`.
+//
+// `GdkDragAction` is a bit mask, so this bit-tests. `DEFAULT`, `PRIVATE` and
+// `ASK` describe how the action was arrived at rather than what the source
+// must now do, so they map to no bit.
+fn drop_operation(action: gdk::DragAction) -> DropOperation {
+    let mut op = DropOperation::NONE;
+    if action.intersects(gdk::DragAction::COPY) {
+        op |= DropOperation::COPY;
+    }
+    if action.intersects(gdk::DragAction::MOVE) {
+        op |= DropOperation::MOVE;
+    }
+    if action.intersects(gdk::DragAction::LINK) {
+        op |= DropOperation::LINK;
+    }
+    op
 }
 
 fn get_cursor_position(window: &gtk::ApplicationWindow) -> Result<CursorPosition, Error> {

--- a/crates/drag/src/platform_impl/macos/mod.rs
+++ b/crates/drag/src/platform_impl/macos/mod.rs
@@ -12,14 +12,37 @@ use objc2::{
 use objc2_foundation::{NSArray, NSData, NSMutableArray, NSPoint, NSRect, NSSize, NSString, NSURL};
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
-use crate::{CursorPosition, DragItem, DragMode, DragResult, Image, Options};
+use crate::{CursorPosition, DragItem, DragMode, DragResult, DropOperation, Image, Options};
 use objc2_app_kit::{
-    NSApp, NSDraggingContext, NSDraggingItem, NSDraggingSession, NSDraggingSource, NSEvent,
-    NSEventModifierFlags, NSEventType, NSImage, NSPasteboardItem, NSPasteboardItemDataProvider,
-    NSView,
+    NSApp, NSDragOperation, NSDraggingContext, NSDraggingItem, NSDraggingSession, NSDraggingSource,
+    NSEvent, NSEventModifierFlags, NSEventType, NSImage, NSPasteboardItem,
+    NSPasteboardItemDataProvider, NSView,
 };
 
 type OnDropCallback = Box<dyn Fn(DragResult, CursorPosition) + Send>;
+
+// The end-of-session `NSDragOperation` → the portable `DropOperation`.
+//
+// `draggingSession:endedAtPoint:operation:` delivers an `NS_OPTIONS` mask, so
+// this bit-tests. `Delete` (a drag to the Trash) is a `MOVE`: the source must
+// remove its data. `Generic` is an unspecified accept that leaves the source
+// data alone, i.e. a `COPY`. `Private` is receiver-internal and imposes
+// nothing on the source, so it maps to no bit — a `Private`-only end is
+// reported as `Dropped` with an empty mask, because the drop did happen (only
+// `NSDragOperationNone` is a cancel).
+fn drop_operation(operation: NSDragOperation) -> DropOperation {
+    let mut op = DropOperation::NONE;
+    if operation.intersects(NSDragOperation::Copy | NSDragOperation::Generic) {
+        op |= DropOperation::COPY;
+    }
+    if operation.intersects(NSDragOperation::Move | NSDragOperation::Delete) {
+        op |= DropOperation::MOVE;
+    }
+    if operation.intersects(NSDragOperation::Link) {
+        op |= DropOperation::LINK;
+    }
+    op
+}
 
 define_class!(
     #[unsafe(super(NSObject))]
@@ -102,7 +125,10 @@ define_class!(
             if operation == objc2_app_kit::NSDragOperation::None {
                 callback_closure(DragResult::Cancel, mouse_location);
             } else {
-                callback_closure(DragResult::Dropped, mouse_location);
+                callback_closure(
+                    DragResult::Dropped(drop_operation(operation)),
+                    mouse_location,
+                );
             }
         }
     }

--- a/crates/drag/src/platform_impl/macos/mod.rs
+++ b/crates/drag/src/platform_impl/macos/mod.rs
@@ -12,7 +12,7 @@ use objc2::{
 use objc2_foundation::{NSArray, NSData, NSMutableArray, NSPoint, NSRect, NSSize, NSString, NSURL};
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
-use crate::{CursorPosition, DragItem, DragMode, DragResult, DropOperation, Image, Options};
+use crate::{CursorPosition, DragItem, DragResult, DropOperation, Image, Options};
 use objc2_app_kit::{
     NSApp, NSDragOperation, NSDraggingContext, NSDraggingItem, NSDraggingSession, NSDraggingSource,
     NSEvent, NSEventModifierFlags, NSEventType, NSImage, NSPasteboardItem,
@@ -20,6 +20,25 @@ use objc2_app_kit::{
 };
 
 type OnDropCallback = Box<dyn Fn(DragResult, CursorPosition) + Send>;
+
+// The inverse of `drop_operation`: `Options::allowed_operations` → the mask
+// `draggingSession:sourceOperationMaskForDraggingContext:` returns, i.e. the
+// operations this source permits the destination to choose from. Only the
+// three portable bits are emitted: `Generic`, `Private` and `Delete` are
+// things a destination reports, not permissions a source grants.
+fn drag_operation_mask(allowed: DropOperation) -> NSDragOperation {
+    let mut mask = NSDragOperation::empty();
+    if allowed.intersects(DropOperation::COPY) {
+        mask |= NSDragOperation::Copy;
+    }
+    if allowed.intersects(DropOperation::MOVE) {
+        mask |= NSDragOperation::Move;
+    }
+    if allowed.intersects(DropOperation::LINK) {
+        mask |= NSDragOperation::Link;
+    }
+    mask
+}
 
 // The end-of-session `NSDragOperation` → the portable `DropOperation`.
 //
@@ -103,7 +122,7 @@ define_class!(
             session
                 .setAnimatesToStartingPositionsOnCancelOrFail(ivars.animate_on_cancel_or_failure);
 
-            ivars.drag_mode.into()
+            drag_operation_mask(ivars.allowed_operations)
         }
 
         #[unsafe(method(draggingSession:endedAtPoint:operation:))]
@@ -137,7 +156,7 @@ define_class!(
 struct DragRsSourceIvars {
     on_drop_callback: OnDropCallback,
     animate_on_cancel_or_failure: bool,
-    drag_mode: DragMode,
+    allowed_operations: DropOperation,
 }
 
 impl DragRsSource {
@@ -151,7 +170,7 @@ impl DragRsSource {
         let this = Self::alloc(mtm).set_ivars(DragRsSourceIvars {
             on_drop_callback,
             animate_on_cancel_or_failure: !options.skip_animatation_on_cancel_or_failure,
-            drag_mode: options.mode,
+            allowed_operations: options.allowed_operations,
         });
         unsafe { msg_send![super(this), init] }
     }

--- a/crates/drag/src/platform_impl/windows/mod.rs
+++ b/crates/drag/src/platform_impl/windows/mod.rs
@@ -4,7 +4,7 @@
 
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
-use crate::{CursorPosition, DragItem, DragMode, DragResult, Image, Options};
+use crate::{CursorPosition, DragItem, DragMode, DragResult, DropOperation, Image, Options};
 
 use std::{
     ffi::c_void,
@@ -22,7 +22,8 @@ use windows::{
         System::Memory::*,
         System::Ole::{DoDragDrop, OleInitialize},
         System::Ole::{
-            IDropSource, IDropSource_Impl, CF_HDROP, DROPEFFECT, DROPEFFECT_COPY, DROPEFFECT_MOVE,
+            IDropSource, IDropSource_Impl, CF_HDROP, DROPEFFECT, DROPEFFECT_COPY, DROPEFFECT_LINK,
+            DROPEFFECT_MOVE,
         },
         System::SystemServices::{MK_LBUTTON, MODIFIERKEYS_FLAGS},
         UI::{
@@ -258,7 +259,10 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
                     let mut pt = POINT { x: 0, y: 0 };
                     GetCursorPos(&mut pt)?;
                     if drop_result == DRAGDROP_S_DROP {
-                        on_drop_callback(DragResult::Dropped, CursorPosition { x: pt.x, y: pt.y });
+                        on_drop_callback(
+                            DragResult::Dropped(drop_operation(out_dropeffect)),
+                            CursorPosition { x: pt.x, y: pt.y },
+                        );
                     } else {
                         // DRAGDROP_S_CANCEL
                         on_drop_callback(DragResult::Cancel, CursorPosition { x: pt.x, y: pt.y });
@@ -298,7 +302,10 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
                     let mut pt = POINT { x: 0, y: 0 };
                     GetCursorPos(&mut pt)?;
                     if drop_result == DRAGDROP_S_DROP {
-                        on_drop_callback(DragResult::Dropped, CursorPosition { x: pt.x, y: pt.y });
+                        on_drop_callback(
+                            DragResult::Dropped(drop_operation(out_dropeffect)),
+                            CursorPosition { x: pt.x, y: pt.y },
+                        );
                     } else {
                         // DRAGDROP_S_CANCEL
                         on_drop_callback(DragResult::Cancel, CursorPosition { x: pt.x, y: pt.y });
@@ -310,6 +317,29 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
     } else {
         Err(crate::Error::UnsupportedWindowHandle)
     }
+}
+
+// `DoDragDrop`'s out `DROPEFFECT` → the portable `DropOperation`.
+//
+// Per the `DoDragDrop` documentation, `pdwEffect` "is set only if the
+// operation is not canceled", so both call sites read it only in the
+// `DRAGDROP_S_DROP` arm. Bit-tested rather than compared, per the
+// `DROPEFFECT` constants documentation ("Your application should always mask
+// values from the DROPEFFECT enumeration to ensure compatibility with future
+// implementations"). `DROPEFFECT_SCROLL` is target-scroll feedback with no
+// source-side obligation, so it falls out of the mask.
+fn drop_operation(effect: DROPEFFECT) -> DropOperation {
+    let mut op = DropOperation::NONE;
+    if (effect & DROPEFFECT_COPY) == DROPEFFECT_COPY {
+        op |= DropOperation::COPY;
+    }
+    if (effect & DROPEFFECT_MOVE) == DROPEFFECT_MOVE {
+        op |= DropOperation::MOVE;
+    }
+    if (effect & DROPEFFECT_LINK) == DROPEFFECT_LINK {
+        op |= DropOperation::LINK;
+    }
+    op
 }
 
 fn get_drag_image(image: Image) -> Option<SHDRAGIMAGE> {

--- a/crates/drag/src/platform_impl/windows/mod.rs
+++ b/crates/drag/src/platform_impl/windows/mod.rs
@@ -4,7 +4,7 @@
 
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
-use crate::{CursorPosition, DragItem, DragMode, DragResult, DropOperation, Image, Options};
+use crate::{CursorPosition, DragItem, DragResult, DropOperation, Image, Options};
 
 use std::{
     ffi::c_void,
@@ -23,7 +23,7 @@ use windows::{
         System::Ole::{DoDragDrop, OleInitialize},
         System::Ole::{
             IDropSource, IDropSource_Impl, CF_HDROP, DROPEFFECT, DROPEFFECT_COPY, DROPEFFECT_LINK,
-            DROPEFFECT_MOVE,
+            DROPEFFECT_MOVE, DROPEFFECT_NONE,
         },
         System::SystemServices::{MK_LBUTTON, MODIFIERKEYS_FLAGS},
         UI::{
@@ -249,10 +249,7 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
                     }
 
                     let mut out_dropeffect = DROPEFFECT::default();
-                    let effect = match options.mode {
-                        DragMode::Copy => DROPEFFECT_COPY,
-                        DragMode::Move => DROPEFFECT_MOVE,
-                    };
+                    let effect = drop_effect(options.allowed_operations);
 
                     let drop_result =
                         DoDragDrop(&data_object, &drop_source, effect, &mut out_dropeffect);
@@ -296,7 +293,7 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
                     let drop_result = DoDragDrop(
                         &data_object,
                         &drop_source,
-                        DROPEFFECT_COPY,
+                        drop_effect(options.allowed_operations),
                         &mut out_dropeffect,
                     );
                     let mut pt = POINT { x: 0, y: 0 };
@@ -319,6 +316,25 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
     }
 }
 
+// The inverse of `drop_operation`: `Options::allowed_operations` →
+// `DoDragDrop`'s `dwOKEffects`, the set of effects the source permits the
+// target to choose from. An empty mask yields `DROPEFFECT_NONE`, under which
+// no target can accept the drop — the honest reading of "this source permits
+// no operation".
+fn drop_effect(allowed: DropOperation) -> DROPEFFECT {
+    let mut effect = DROPEFFECT_NONE;
+    if allowed.intersects(DropOperation::COPY) {
+        effect |= DROPEFFECT_COPY;
+    }
+    if allowed.intersects(DropOperation::MOVE) {
+        effect |= DROPEFFECT_MOVE;
+    }
+    if allowed.intersects(DropOperation::LINK) {
+        effect |= DROPEFFECT_LINK;
+    }
+    effect
+}
+
 // `DoDragDrop`'s out `DROPEFFECT` → the portable `DropOperation`.
 //
 // Per the `DoDragDrop` documentation, `pdwEffect` "is set only if the
@@ -330,13 +346,13 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
 // source-side obligation, so it falls out of the mask.
 fn drop_operation(effect: DROPEFFECT) -> DropOperation {
     let mut op = DropOperation::NONE;
-    if (effect & DROPEFFECT_COPY) == DROPEFFECT_COPY {
+    if effect.contains(DROPEFFECT_COPY) {
         op |= DropOperation::COPY;
     }
-    if (effect & DROPEFFECT_MOVE) == DROPEFFECT_MOVE {
+    if effect.contains(DROPEFFECT_MOVE) {
         op |= DropOperation::MOVE;
     }
-    if (effect & DROPEFFECT_LINK) == DROPEFFECT_LINK {
+    if effect.contains(DROPEFFECT_LINK) {
         op |= DropOperation::LINK;
     }
     op

--- a/crates/drag/tests/drop_operation.rs
+++ b/crates/drag/tests/drop_operation.rs
@@ -1,0 +1,67 @@
+// Copyright 2023-2023 CrabNebula Ltd.
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+use drag::DropOperation;
+
+#[test]
+fn mask_operations() {
+    let mask = DropOperation::COPY | DropOperation::LINK;
+    assert!(mask.intersects(DropOperation::COPY));
+    assert!(mask.intersects(DropOperation::LINK));
+    assert!(!mask.intersects(DropOperation::MOVE));
+    assert!(!mask.is_empty());
+    assert_eq!(mask.bits(), 0b101);
+
+    assert!(DropOperation::NONE.is_empty());
+    assert!(!DropOperation::NONE.intersects(mask));
+
+    let mut mask = DropOperation::NONE;
+    mask |= DropOperation::MOVE;
+    assert_eq!(mask, DropOperation::MOVE);
+}
+
+#[test]
+fn from_bits_truncate_drops_undefined_bits() {
+    assert_eq!(
+        DropOperation::from_bits_truncate(u32::MAX),
+        DropOperation::COPY | DropOperation::MOVE | DropOperation::LINK
+    );
+    assert_eq!(DropOperation::from_bits_truncate(0), DropOperation::NONE);
+    assert_eq!(
+        DropOperation::from_bits_truncate(DropOperation::MOVE.bits()),
+        DropOperation::MOVE
+    );
+}
+
+#[cfg(feature = "serde")]
+mod serde_wire {
+    use drag::{DragResult, DropOperation};
+
+    #[test]
+    fn drop_operation_is_a_bare_number_on_the_wire() {
+        let mask = DropOperation::COPY | DropOperation::LINK;
+        assert_eq!(serde_json::to_string(&mask).unwrap(), "5");
+        let back: DropOperation = serde_json::from_str("5").unwrap();
+        assert_eq!(back, mask);
+    }
+
+    #[test]
+    fn deserialization_truncates_undefined_bits() {
+        // Without routing through `from_bits_truncate`, this would build a
+        // mask that intersects everything.
+        let back: DropOperation = serde_json::from_str("4294967295").unwrap();
+        assert_eq!(
+            back,
+            DropOperation::COPY | DropOperation::MOVE | DropOperation::LINK
+        );
+    }
+
+    #[test]
+    fn drag_result_wire_shape() {
+        let dropped = DragResult::Dropped(DropOperation::MOVE);
+        assert_eq!(serde_json::to_string(&dropped).unwrap(), r#"{"Dropped":2}"#);
+        let cancel = DragResult::Cancel;
+        assert_eq!(serde_json::to_string(&cancel).unwrap(), r#""Cancel""#);
+    }
+}

--- a/crates/drag/tests/drop_operation.rs
+++ b/crates/drag/tests/drop_operation.rs
@@ -22,6 +22,13 @@ fn mask_operations() {
 }
 
 #[test]
+fn options_default_permits_exactly_a_copy() {
+    let options = drag::Options::default();
+    assert_eq!(options.allowed_operations, DropOperation::COPY);
+    assert!(!options.skip_animatation_on_cancel_or_failure);
+}
+
+#[test]
 fn from_bits_truncate_drops_undefined_bits() {
     assert_eq!(
         DropOperation::from_bits_truncate(u32::MAX),

--- a/crates/tauri-plugin-drag-as-window/src/commands.rs
+++ b/crates/tauri-plugin-drag-as-window/src/commands.rs
@@ -54,13 +54,15 @@ pub enum DragMode {
     #[default]
     Copy,
     Move,
+    Link,
 }
 
-impl From<DragMode> for drag::DragMode {
+impl From<DragMode> for drag::DropOperation {
     fn from(value: DragMode) -> Self {
         match value {
-            DragMode::Copy => Self::Copy,
-            DragMode::Move => Self::Move,
+            DragMode::Copy => Self::COPY,
+            DragMode::Move => Self::MOVE,
+            DragMode::Link => Self::LINK,
         }
     }
 }
@@ -75,7 +77,7 @@ impl From<DragOptions> for drag::Options {
     fn from(options: DragOptions) -> Self {
         Self {
             skip_animatation_on_cancel_or_failure: true,
-            mode: options.mode.into(),
+            allowed_operations: options.mode.into(),
         }
     }
 }

--- a/crates/tauri-plugin-drag/src/commands.rs
+++ b/crates/tauri-plugin-drag/src/commands.rs
@@ -82,13 +82,15 @@ pub enum DragMode {
     #[default]
     Copy,
     Move,
+    Link,
 }
 
-impl From<DragMode> for drag::DragMode {
+impl From<DragMode> for drag::DropOperation {
     fn from(value: DragMode) -> Self {
         match value {
-            DragMode::Copy => Self::Copy,
-            DragMode::Move => Self::Move,
+            DragMode::Copy => Self::COPY,
+            DragMode::Move => Self::MOVE,
+            DragMode::Link => Self::LINK,
         }
     }
 }
@@ -103,7 +105,7 @@ impl From<DragOptions> for drag::Options {
     fn from(options: DragOptions) -> Self {
         Self {
             skip_animatation_on_cancel_or_failure: false,
-            mode: options.mode.into(),
+            allowed_operations: options.mode.into(),
         }
     }
 }

--- a/packages/tauri-plugin-drag-api/guest-js/index.ts
+++ b/packages/tauri-plugin-drag-api/guest-js/index.ts
@@ -4,7 +4,16 @@ export type DragItem =
   | string[]
   | { data: string | Record<string, string>; types: string[] };
 
-export type DragResult = "Dropped" | "Cancelled";
+/**
+ * The result of a drag operation.
+ *
+ * `Dropped` carries the operation the drop target negotiated, as a bit mask:
+ * copy = 1, move = 2, link = 4. A mask of 0 means the target accepted the
+ * drop but performed nothing. (This matches the Rust `DragResult` wire
+ * format; the previous `"Dropped" | "Cancelled"` type never matched the
+ * `Cancel` arm.)
+ */
+export type DragResult = { Dropped: number } | "Cancel";
 
 /**
  * Logical position of the cursor.

--- a/packages/tauri-plugin-drag-api/guest-js/index.ts
+++ b/packages/tauri-plugin-drag-api/guest-js/index.ts
@@ -26,7 +26,7 @@ export interface CursorPosition {
 export interface Options {
   item: DragItem;
   icon: string;
-  mode?: "copy" | "move";
+  mode?: "copy" | "move" | "link";
 }
 
 export interface CallbackPayload {

--- a/packages/tauri-plugin-drag-as-window-api/guest-js/index.ts
+++ b/packages/tauri-plugin-drag-as-window-api/guest-js/index.ts
@@ -1,7 +1,13 @@
 import { Channel, invoke } from "@tauri-apps/api/core";
 import html2canvas from "html2canvas";
 
-type DragResult = "Dropped" | "Cancelled";
+/**
+ * `Dropped` carries the operation the drop target negotiated, as a bit mask:
+ * copy = 1, move = 2, link = 4. (This matches the Rust `DragResult` wire
+ * format; the previous `"Dropped" | "Cancelled"` type never matched the
+ * `Cancel` arm.)
+ */
+type DragResult = { Dropped: number } | "Cancel";
 
 /**
  * Logical position of the cursor.

--- a/packages/tauri-plugin-drag-as-window-api/guest-js/index.ts
+++ b/packages/tauri-plugin-drag-as-window-api/guest-js/index.ts
@@ -27,7 +27,7 @@ export interface CallbackPayload {
 }
 
 export interface DragOptions {
-  mode?: "copy" | "move";
+  mode?: "copy" | "move" | "link";
 }
 
 /**


### PR DESCRIPTION
`drag` currently cannot express a drag-and-drop *negotiation* in either direction, and the two halves only make sense together.

**Inbound:** `DragResult` is `Dropped | Cancel`, so a consumer cannot tell *what the target did* — only that something was dropped. That matters because the negotiated operation is an instruction to the **source**: after a move it must delete its original, after a copy it must not, and after a drop that resolved to "no effect" it must do neither. Today the only option is to assume the operation the source proposed, which is wrong whenever the target chose differently — and actively destructive in the `DRAGDROP_S_DROP` + `DROPEFFECT_NONE` case (the target accepted the drop, performed nothing, and the source deletes its data anyway).

**Outbound:** `Options.mode` is a binary `Copy | Move` (never `Link`), and on Windows it becomes the whole of `DoDragDrop`'s `dwOKEffects` — so a conforming target can only ever return that one effect or none. The negotiation is foreclosed before the target sees the drag.

Neither half needs a new OS call. The result value is already sitting in a local at all four callback sites and is discarded (Windows twice — both `DoDragDrop` calls; macOS — the `draggingSession:endedAtPoint:operation:` argument; GTK — `context.selected_action()`, currently read only to trace-log it), and all three platform arms already compute their permission channel from `mode` — they just need a wider input.

**Change 1 — `DragResult::Dropped(DropOperation)`.** `DropOperation` is a small portable bit mask (`COPY | MOVE | LINK`) each platform normalizes into. A mask rather than an enum because `NSDragOperation` is `NS_OPTIONS`, `GdkDragAction` is a flag set, and the `DROPEFFECT` documentation explicitly forbids equality comparison ("Your application should always mask values … never compare a DROPEFFECT against, say, DROPEFFECT_COPY"). Platform bits with no source-side obligation are dropped rather than invented into the portable set (`DROPEFFECT_SCROLL`, `NSDragOperationPrivate`, `GdkDragAction::{DEFAULT, PRIVATE, ASK}`); `NSDragOperationDelete` folds to `MOVE` and `NSDragOperationGeneric` to `COPY`, matching what the source must do about them. On Windows `pdwEffect` is read only in the `DRAGDROP_S_DROP` branch, per its documentation ("set only if the operation is not canceled"). Consumers that want a single action apply their own priority to the mask — which they must anyway, since the platforms disagree about the natural priority order.

This is a **`serde` wire break that lands inside this repo**: external tagging renders the newtype variant as `{"Dropped": <mask>}` where it was `"Dropped"`. `tauri-plugin-drag` and `tauri-plugin-drag-as-window` forward `drag::DragResult` to the webview verbatim, so this PR updates both TS `DragResult` types in the same pass — which also fixes a pre-existing bug in them: they declared `"Cancelled"`, while the Rust variant serializes as `"Cancel"`, so the cancel arm never matched. The alternative that avoids the wire break — keeping `Dropped` a unit variant plus a separate `operation` field — would make an operation representable for a cancelled drag; since the plugins ship in this repo and are updated in the same commit, the honest variant seemed better. Happy to do it the other way if JS wire stability matters more.

**Change 2 — `Options.mode: DragMode` → `Options.allowed_operations: DropOperation`.** The same type used for the question instead of the answer: the source declares the set of operations it permits, and each arm hands it to its existing permission channel — `dwOKEffects` (Windows), the `sourceOperationMaskForDraggingContext:` return (macOS), the source's `GdkDragAction` (GTK) — as a three-bit fold that is the exact inverse of change 1's normalization. `DragMode` is deleted rather than deprecated: it answered the same question strictly worse, and keeping both would leave two vocabularies for one concept. `Options::default()` still permits exactly a copy, so default-options callers see no change. Behaviour change worth its changelog line: an `allowed_operations` with no defined bits makes the drag undroppable (`DROPEFFECT_NONE` / empty masks) — where the old design's only near-equivalent silently offered a copy and then reported the proposed action. Drive-by in the same lines: the Windows `DragItem::Data` branch hardcoded `DROPEFFECT_COPY` and ignored `Options` entirely; it now honours the mask like the `Files` branch. The plugins' `mode` option gains `"link"`.

`DropOperation` has no `Default` (it could only be the empty mask, which as an `allowed_operations` is an undroppable drag — not a value to reach by omitting a field), and under the `serde` feature it deserializes through `from_bits_truncate` (`#[serde(from = "u32")]`), so a wire value like `4294967295` cannot become a mask that intersects everything. Tests cover the mask semantics, the default, and the serde round trips including that clamp.

One unrelated bug spotted next door, deliberately not included: in both Windows branches, `GetCursorPos(&mut pt)?` runs *between* `DoDragDrop` and the callback, so a `GetCursorPos` failure makes a completed drop report as a failed drag (the callback never fires).

A covector change file is included (major across the five packages).

<sup>This PR was generated by Claude</sup>
