### PR TITLE
feat(windows): optional timeout to cancel a DoDragDrop that never returns

### DIFF
--- a/crates/drag/Cargo.toml
+++ b/crates/drag/Cargo.toml
@@ -62,6 +62,8 @@ windows = { version = "0.52", features = [
   "Win32_System_Ole",
   "Win32_System_Memory",
   "Win32_System_SystemServices",
+  "Win32_System_Threading",
+  "Win32_UI_Input_KeyboardAndMouse",
   "Win32_UI_Shell",
   "Win32_UI_Shell_Common",
   "Win32_UI_WindowsAndMessaging",

--- a/crates/drag/src/lib.rs
+++ b/crates/drag/src/lib.rs
@@ -160,6 +160,54 @@ pub struct Options {
     pub mode: DragMode,
 }
 
+/// Milliseconds, where 0 means disabled.
+///
+/// Process-wide rather than a field on [`Options`] for two reasons. It keeps the
+/// addition non-breaking, since `Options` has public fields and no
+/// `#[non_exhaustive]`, so a new field would break every struct-literal
+/// construction downstream. And it matches what this actually is: a safety net
+/// against a platform bug, not a preference anyone would want to vary from one
+/// drag to the next.
+static STUCK_DRAG_TIMEOUT_MS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Cancel a drag that has stopped responding.
+///
+/// `DoDragDrop` runs its own modal message loop on the calling thread and holds
+/// the mouse capture until the drag ends. When it fails to exit, the caller's
+/// thread never returns; on a UI thread that takes the whole application with
+/// it, while the process still reports as responding.
+///
+/// Once set, a background thread cancels the drag if it has held the mouse
+/// capture for this long with no mouse button pressed. Unset by default, so
+/// behaviour is unchanged unless you opt in.
+///
+/// Pick a value in seconds rather than milliseconds. Releasing the button does
+/// not end a drag: `DoDragDrop` then calls `IDropTarget::Drop` on the receiving
+/// application and keeps the capture until that call returns, so a slow drop
+/// target legitimately holds it with no button down. Erring long costs a few
+/// seconds; erring short cancels a real drop.
+///
+/// - **Windows**: supported.
+/// - **macOS / Linux**: stored but unused.
+///
+/// ```rust,no_run
+/// drag::set_stuck_drag_timeout(Some(std::time::Duration::from_secs(5)));
+/// ```
+pub fn set_stuck_drag_timeout(timeout: Option<std::time::Duration>) {
+    let ms = timeout
+        .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX).max(1))
+        .unwrap_or(0);
+    STUCK_DRAG_TIMEOUT_MS.store(ms, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// The timeout set by [`set_stuck_drag_timeout`], or `None` if disabled.
+pub fn stuck_drag_timeout() -> Option<std::time::Duration> {
+    match STUCK_DRAG_TIMEOUT_MS.load(std::sync::atomic::Ordering::Relaxed) {
+        0 => None,
+        ms => Some(std::time::Duration::from_millis(ms)),
+    }
+}
+
 /// An image definition.
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]

--- a/crates/drag/src/platform_impl/windows/mod.rs
+++ b/crates/drag/src/platform_impl/windows/mod.rs
@@ -25,6 +25,7 @@ use windows::{
             IDropSource, IDropSource_Impl, CF_HDROP, DROPEFFECT, DROPEFFECT_COPY, DROPEFFECT_MOVE,
         },
         System::SystemServices::{MK_LBUTTON, MODIFIERKEYS_FLAGS},
+        System::Threading::GetCurrentThreadId,
         UI::{
             Shell::{
                 BHID_DataObject, CLSID_DragDropHelper, Common, IDragSourceHelper, IShellItemArray,
@@ -36,6 +37,7 @@ use windows::{
 };
 
 mod image;
+mod watchdog;
 
 static mut OLE_RESULT: Result<()> = Ok(());
 static OLE_UNINITIALIZE: Once = Once::new();
@@ -253,8 +255,24 @@ pub fn start_drag<W: HasWindowHandle, F: Fn(DragResult, CursorPosition) + Send +
                         DragMode::Move => DROPEFFECT_MOVE,
                     };
 
+                    // `DoDragDrop` blocks this thread and holds the mouse capture
+                    // until the drag ends. If it never returns, so does this
+                    // thread. `watchdog` cancels that case from the outside; see
+                    // its module docs for why a timeout inside
+                    // `QueryContinueDrag` cannot do the job.
+                    let alive = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+                    if let Some(timeout) = crate::stuck_drag_timeout() {
+                        let alive = alive.clone();
+                        let thread_id = GetCurrentThreadId();
+                        std::thread::spawn(move || watchdog::watch(thread_id, alive, timeout));
+                    }
+
                     let drop_result =
                         DoDragDrop(&data_object, &drop_source, effect, &mut out_dropeffect);
+
+                    // Stops the watchdog immediately on every normal drag, so it
+                    // never samples a thread that is no longer dragging.
+                    alive.store(false, std::sync::atomic::Ordering::SeqCst);
                     let mut pt = POINT { x: 0, y: 0 };
                     GetCursorPos(&mut pt)?;
                     if drop_result == DRAGDROP_S_DROP {

--- a/crates/drag/src/platform_impl/windows/watchdog.rs
+++ b/crates/drag/src/platform_impl/windows/watchdog.rs
@@ -1,0 +1,151 @@
+// Copyright 2023-2023 CrabNebula Ltd.
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+//! Recovery for a `DoDragDrop` that stops responding.
+//!
+//! `DoDragDrop` runs its own modal message loop on the calling thread and holds
+//! the mouse capture until the drag ends. When it fails to exit, the caller's
+//! thread never returns, which for a UI thread means the whole application goes
+//! with it: no repaint, no input, no timers, while the process still reports as
+//! responding because it *is* pumping messages, just not the application's.
+//!
+//! ## Why this cannot live in `IDropSource::QueryContinueDrag`
+//!
+//! That is the obvious place to put a timeout and it does not work. In the stuck
+//! state `DoDragDrop` is spinning inside `PeekMessage` on an empty queue and is
+//! not calling `QueryContinueDrag` at all, so a deadline checked there is never
+//! evaluated. Measured on a real occurrence: 24 of 24 instruction-pointer samples
+//! of the wedged thread landed inside `NtUserPeekMessage`, with an 84% kernel /
+//! 2.2% user split, which is a spin on an empty queue rather than a wait on a
+//! slow drop target.
+//!
+//! The recovery therefore has to come from outside the drag. Posting a
+//! `VK_ESCAPE` pair to the window holding the capture gives the modal loop a
+//! message to consume, at which point it calls `QueryContinueDrag` again and the
+//! existing escape branch returns `DRAGDROP_S_CANCEL` through the normal path.
+
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant},
+};
+
+use windows::Win32::{
+    Foundation::{HWND, LPARAM, WPARAM},
+    UI::{
+        Input::KeyboardAndMouse::{GetAsyncKeyState, VK_ESCAPE, VK_LBUTTON, VK_RBUTTON},
+        WindowsAndMessaging::{
+            GetClassNameW, GetGUIThreadInfo, PostMessageW, GUITHREADINFO, WM_KEYDOWN, WM_KEYUP,
+        },
+    },
+};
+
+/// The window class OLE uses for the drag's modal loop. The watchdog will not
+/// post to anything else, so it can never disturb an unrelated capture.
+const OLE_DRAG_CLASS: &str = "CLIPBRDWNDCLASS";
+
+/// How often the state is sampled. Small relative to any sane timeout, and the
+/// work per tick is three cheap syscalls.
+const POLL: Duration = Duration::from_millis(250);
+
+/// Watches the dragging thread and cancels a drag that is holding the mouse
+/// capture with no button pressed for longer than `timeout`.
+///
+/// `alive` is cleared by the caller as soon as `DoDragDrop` returns, so a normal
+/// drag of any length stops this thread without it ever acting.
+pub(crate) fn watch(thread_id: u32, alive: Arc<AtomicBool>, timeout: Duration) {
+    // Measured from when the drag first looks stuck, NOT from when it started,
+    // because a legitimate slow `IDropTarget::Drop` also holds the capture with
+    // no button down. Erring long costs the user a few seconds; erring short
+    // cancels a real drop and loses them the file.
+    let mut stuck_since: Option<Instant> = None;
+
+    while alive.load(Ordering::SeqCst) {
+        std::thread::sleep(POLL);
+        if !alive.load(Ordering::SeqCst) {
+            return;
+        }
+
+        let capture = match stuck_capture(thread_id) {
+            Some(hwnd) => hwnd,
+            None => {
+                stuck_since = None;
+                continue;
+            }
+        };
+
+        match stuck_since {
+            None => stuck_since = Some(Instant::now()),
+            Some(since) if since.elapsed() >= timeout => {
+                log::warn!(
+                    "drag: DoDragDrop held the mouse capture for {:?} with no button down; \
+                     cancelling it with VK_ESCAPE",
+                    since.elapsed()
+                );
+                cancel(capture);
+                return;
+            }
+            Some(_) => {}
+        }
+    }
+}
+
+/// `Some(hwnd)` when the dragging thread holds the capture through OLE's drag
+/// window and no mouse button is down, which together mean the drag has outlived
+/// the gesture that started it.
+fn stuck_capture(thread_id: u32) -> Option<HWND> {
+    if mouse_button_down() {
+        return None;
+    }
+
+    let mut info = GUITHREADINFO {
+        cbSize: std::mem::size_of::<GUITHREADINFO>() as u32,
+        ..Default::default()
+    };
+    // SAFETY: `info` is a correctly sized, zeroed GUITHREADINFO.
+    unsafe { GetGUIThreadInfo(thread_id, &mut info) }.ok()?;
+
+    let capture = info.hwndCapture;
+    if capture.0 == 0 {
+        return None;
+    }
+
+    let mut class = [0u16; 64];
+    // SAFETY: `capture` came from GetGUIThreadInfo; the buffer bounds the write.
+    let len = unsafe { GetClassNameW(capture, &mut class) };
+    if len <= 0 {
+        return None;
+    }
+
+    if String::from_utf16_lossy(&class[..len as usize]) == OLE_DRAG_CLASS {
+        Some(capture)
+    } else {
+        None
+    }
+}
+
+fn mouse_button_down() -> bool {
+    // SAFETY: GetAsyncKeyState takes a virtual key code and has no preconditions.
+    unsafe {
+        (GetAsyncKeyState(VK_LBUTTON.0 as i32) as u16 & 0x8000) != 0
+            || (GetAsyncKeyState(VK_RBUTTON.0 as i32) as u16 & 0x8000) != 0
+    }
+}
+
+/// Ends the drag the way the user would, through `QueryContinueDrag`'s own
+/// escape branch.
+///
+/// Deliberately *not* `ReleaseCapture`: taking the capture away from OLE leaves
+/// it believing a drag is still in progress, which trades one bad state for a
+/// worse one.
+fn cancel(capture: HWND) {
+    // SAFETY: posting is asynchronous and does not dereference anything; an
+    // invalid window simply fails.
+    unsafe {
+        let _ = PostMessageW(capture, WM_KEYDOWN, WPARAM(VK_ESCAPE.0 as usize), LPARAM(0));
+        let _ = PostMessageW(capture, WM_KEYUP, WPARAM(VK_ESCAPE.0 as usize), LPARAM(0));
+    }
+}


### PR DESCRIPTION
Closes #94.

Adds an opt-in `Options::stuck_drag_timeout`. When set, a background thread cancels a drag that has held the mouse capture for that long with no mouse button pressed. It is `None` by default, so nothing changes for anyone who does not set it.

## Why not a timeout in `QueryContinueDrag`

That was my first attempt and it cannot work, which I think is the interesting part of this.

In the stuck state `DoDragDrop` is spinning inside `PeekMessage` on an empty queue and is **not calling `QueryContinueDrag` at all**, so a deadline checked there is never evaluated. From the measurements in #94: 24 of 24 instruction-pointer samples of the wedged thread landed inside `NtUserPeekMessage`, and the CPU split was 84% kernel to 2.2% user, which is a spin on an empty queue rather than a wait on a slow drop target.

So the recovery has to come from outside the drag. Posting a `VK_ESCAPE` pair to the window holding the capture gives the modal loop a message to consume, at which point it calls `QueryContinueDrag` again and `DropSource`'s existing escape branch returns `DRAGDROP_S_CANCEL` through the normal path. Nothing about the existing `IDropSource` implementation changes.

## What it does

`crates/drag/src/platform_impl/windows/watchdog.rs`, spawned only when the option is set, stopped by an `AtomicBool` the moment `DoDragDrop` returns.

Each tick it asks three questions, and all three must hold before the clock even starts:

1. `GetAsyncKeyState` says no mouse button is down.
2. `GetGUIThreadInfo` on the dragging thread reports a capture window.
3. `GetClassNameW` on that window returns `CLIPBRDWNDCLASS`, which is the class OLE uses for the drag's own modal loop.

Three deliberate choices in there:

- **The grace period is measured from when it first looks stuck, not from when the drag started.** Releasing the button does not end a drag: `DoDragDrop` then calls `IDropTarget::Drop` on the receiving application and keeps the capture until that returns, so a slow drop target legitimately holds it with no button down. Erring long costs the user a few seconds. Erring short cancels a real drop and loses them the file. My own first version used 1.5s and would have done exactly that, which is why the doc comment suggests seconds rather than milliseconds.
- **It only ever posts to `CLIPBRDWNDCLASS`**, so it cannot disturb an unrelated capture held by the application for its own reasons.
- **It never calls `ReleaseCapture`.** Forcing the capture away would leave OLE believing a drag is still in progress, which trades one bad state for a worse one.

## Semver

This is the one thing worth a decision rather than a review.

`Options` has public fields and no `#[non_exhaustive]`, so **adding a field is technically breaking** for anyone constructing it with a struct literal rather than `..Default::default()`. It broke both in-repo plugin crates, which are updated here to pass `None`.

If you would rather this land in a patch release, I am happy to rework it as a builder method, or to add `#[non_exhaustive]` at the same time so the next one is free. Say which and I will push it.

## Not included

I left `stuck_drag_timeout` unexposed in `tauri-plugin-drag`'s JS options to keep the change focused. It is a small follow-up if you want it.

## Checks

- `cargo check --workspace` clean
- `cargo clippy --workspace -- -D warnings` clean
- `cargo fmt --check --all` clean
- Ran against the real failure in my own app, where the same approach has been running since 28 August. Posting the escape pair took the wedged thread from 82.8% of a core to 0.4%, released the capture, and the application resumed with no restart.

Windows 11 25H2, x86_64.